### PR TITLE
Fixed 'css' folder error.

### DIFF
--- a/lib/compass.js
+++ b/lib/compass.js
@@ -39,7 +39,7 @@ compass.compile = function(filePath, opts, callback) {
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', function(data) {
     stdout += data;
-    var css = /([^ ]+.css)/.exec(data);
+    var css = /([^ ]+\.css)/.exec(data);
     if (css) {
       fileList.push(path.join(opts.project, css[1]));
     }


### PR DESCRIPTION
When using 'css' folder somewhere in the path, error occured because compass output was filtered to path, not file. Fixed by correcting regexp.